### PR TITLE
set fixed width to level character class in meta format string

### DIFF
--- a/log.lua
+++ b/log.lua
@@ -21,7 +21,7 @@ log.modes = {
 
 for mode, color in pairs(log.modes) do
    log[mode] = function(msg)
-      local meta = string.format('[%s %s] ',
+      local meta = string.format('[%-6s%s] ',
          mode:upper(), os.date("%H:%M:%S"))
       
       local content


### PR DESCRIPTION
Maybe it's just my personal feeling, but I think this output is better to read:
```
[INFO  19:05:33] humu
[DEBUG 19:05:33] humu
```
then this:
```
[INFO 19:05:15] humu
[DEBUG 19:05:15] humu
```
Especially in longer log files.

PS: Thanks for this tiny logging module :)